### PR TITLE
WIP: ccache compatibility for CUDA builds

### DIFF
--- a/classes/cuda.bbclass
+++ b/classes/cuda.bbclass
@@ -13,8 +13,17 @@ CUDA_LDFLAGS = "\
 LDFLAGS_prepend_cuda = "${TOOLCHAIN_OPTIONS} "
 LDFLAGS_append_cuda = " ${CUDA_LDFLAGS}"
 
-export CUDAHOSTCXX = "${@d.getVar('CXX').split()[0]}"
-export CUDAFLAGS = "${CUDA_NVCC_FLAGS} ${@' '.join(['-Xcompiler ' + arg for arg in d.getVar('CXX').split()[1:]])}"
+def cuda_extract_compiler(compiler, d, prefix='-Xcompiler '):
+    args = d.getVar(compiler).split()
+    if args[0] == "ccache":
+        return args[1], ' '.join([prefix + arg for arg in args[2:]])
+    return args[0], ' '.join([prefix + arg for arg in args[1:]])
+
+export CUDAHOSTCXX = "${@cuda_extract_compiler('CXX', d)[0]}"
+export CUDAFLAGS = "-ccbin ${@cuda_extract_compiler('CXX', d)[0]} ${CUDA_NVCC_FLAGS} ${@cuda_extract_compiler('CXX', d)[1]}"
+OECMAKE_CUDA_COMPILER_LAUNCHER ?= "${CCACHE}"
+OECMAKE_CUDA_COMPILER ?= "nvcc"
+CUDA_CCACHE_COMPILERCHECK ?= "cuda-compiler-check %compiler%"
 
 # The following are for the old-style FindCUDA.cmake module (pre-3.8)
 CUDA_EXTRA_OECMAKE = '\
@@ -26,7 +35,7 @@ EXTRA_OECMAKE_append_cuda = " ${CUDA_EXTRA_OECMAKE}"
 
 export CUDA_TOOLKIT_ROOT = "${STAGING_DIR_NATIVE}/usr/local/cuda-${CUDA_VERSION}"
 export CUDA_NVCC_EXECUTABLE = "${CUDA_TOOLKIT_ROOT}/bin/nvcc"
-export CUDACXX = "${CUDA_TOOLKIT_ROOT}/bin/nvcc"
+export CUDACXX = "${CCACHE}${CUDA_TOOLKIT_ROOT}/bin/nvcc"
 export CUDA_PATH = "${STAGING_DIR_HOST}/usr/local/cuda-${CUDA_VERSION}"
 
 CUDA_NATIVEDEPS = "cuda-compiler-native cuda-cudart-native"
@@ -43,9 +52,17 @@ cmake_do_generate_toolchain_file_append_cuda() {
 set(CMAKE_CUDA_TOOLKIT_ROOT_DIR "${STAGING_DIR_NATIVE}/usr/local/cuda-${CUDA_VERSION}" CACHE PATH "" FORCE)
 set(CMAKE_CUDA_TOOLKIT_TARGET_DIR "${STAGING_DIR_HOST}/usr/local/cuda-${CUDA_VERSION}" CACHE PATH "" FORCE)
 set(CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES "\${CMAKE_CUDA_TOOLKIT_ROOT_DIR}/include" "\${CMAKE_CUDA_TOOLKIT_TARGET_DIR}/include" CACHE PATH "" FORCE)
+set(CMAKE_CUDA_COMPILER ${OECMAKE_CUDA_COMPILER})
+set(CMAKE_CUDA_COMPILER_LAUNCHER ${OECMAKE_CUDA_COMPILER_LAUNCHER})
 EOF
 }
 
 PACKAGE_ARCH_cuda = "${SOC_FAMILY_PKGARCH}"
 RDEPENDS_${PN}_append_tegra = " tegra-libraries"
 
+python() {
+    if bb.data.inherits_class('ccache', d):
+        d.appendVar('DEPENDS', ' cuda-compiler-check-native')
+        if (d.getVar('CCACHE_COMPILERCHECK') or '') != '':
+            d.prependVar('CCACHE_COMPILERCHECK', '${CUDA_CCACHE_COMPILERCHECK} ')
+}

--- a/recipes-devtools/ccache/cuda-compiler-check-native_1.0.bb
+++ b/recipes-devtools/ccache/cuda-compiler-check-native_1.0.bb
@@ -1,0 +1,18 @@
+DESCRIPTION = "CCACHE_COMPILERCHECK wrapper for CUDA"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://cuda-compiler-check.sh"
+
+inherit native
+
+S = "${WORKDIR}"
+
+do_compile() {
+    :
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/cuda-compiler-check.sh ${D}${bindir}/cuda-compiler-check
+}

--- a/recipes-devtools/ccache/cuda-compiler-check/cuda-compiler-check.sh
+++ b/recipes-devtools/ccache/cuda-compiler-check/cuda-compiler-check.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+compiler="$1"
+shift
+if [ $(basename "$compiler") = "nvcc" ]; then
+    "$compiler" --version
+else
+    "$@"
+fi

--- a/recipes-devtools/cuda/cuda-samples_10.0.326-1.bb
+++ b/recipes-devtools/cuda/cuda-samples_10.0.326-1.bb
@@ -40,8 +40,8 @@ S = "${WORKDIR}/${BP}"
 B = "${S}"
 
 CUDA_PATH = "/usr/local/cuda-${CUDA_VERSION}"
-CC_FIRST = "${@d.getVar('CC').split()[0]}"
-CC_REST = "${@' '.join(d.getVar('CC').split()[1:])}"
+CC_FIRST = "${@cuda_extract_compiler('CC', d)[0]}"
+CC_REST = "${@cuda_extract_compiler('CC', d, prefix='')[1]}"
 CFLAGS += "-I=${CUDA_PATH}/include"
 EXTRA_NVCCFLAGS = "-I${STAGING_DIR_HOST}${CUDA_PATH}/include"
 


### PR DESCRIPTION
For https://github.com/OE4T/meta-tegra/issues/474

Applying the work from https://github.com/OE4T/meta-tegra/pull/481 to `dunfell` branch.

Tested on Jenkins + GCC 7/8 + ccache to build `cuda=v10.0.326`, `OpenCV=v4.1.0` and `TensorRT=v6.0.1`.